### PR TITLE
過去のクエストから経験値得られないように

### DIFF
--- a/app/controllers/user_contents_controller.rb
+++ b/app/controllers/user_contents_controller.rb
@@ -2,14 +2,16 @@ class UserContentsController < ApplicationController
     def create
       @content = Content.find(params[:content_id])
       @quest = Quest.find(params[:myquest_id])
-      @user_contents = UserContent.new(user_contents_params)
-      @user_contents.user_id = current_user.id
-      @user_contents.content_id = params[:content_id]
-      @user_contents.is_finished = true
-      @user_contents.save
-      current_user.get_nekokan(@user_contents.nekokan)
-      if @quest.finished?(current_user)
-        current_user.get_nekokan(@quest.total_nekokan(current_user))
+      if current_user.user_contents.find_by(content_id: @content.id).nil? && @quest.current_quest?
+        @user_contents = UserContent.new(user_contents_params)
+        @user_contents.user_id = current_user.id
+        @user_contents.content_id = params[:content_id]
+        @user_contents.is_finished = true
+        @user_contents.save
+        current_user.get_nekokan(@user_contents.nekokan)
+        if @quest.finished?(current_user)
+          current_user.get_nekokan(@quest.total_nekokan(current_user))
+        end
       end
     end
 


### PR DESCRIPTION
# 概要
#74 
* 過去のクエストから経験値得られないように

## やったこと
* 動画のdone判定を再読み込みとか関係なしに一度きりに
* done判定するのは生きてるクエストの時のみに
  * doneした時だけ経験値を得られるので結果的に過去のクエストから経験値は取れない

Closes #74 